### PR TITLE
avl6882 wrong frequency range

### DIFF
--- a/drivers/media/dvb-frontends/avl6882.c
+++ b/drivers/media/dvb-frontends/avl6882.c
@@ -1313,7 +1313,7 @@ static int avl6882_set_property(struct dvb_frontend *fe,
 		}
 		switch (data) {
 		case SYS_DVBC_ANNEX_A:
-			fe->ops.info.frequency_min_hz = 470 * MHz;
+			fe->ops.info.frequency_min_hz = 47 * MHz;
 			fe->ops.info.frequency_max_hz = 862 * MHz;
 			fe->ops.info.frequency_stepsize_hz = 62500;
 			break;


### PR DESCRIPTION
The lower frequency boundary is to high. It is 47 MHz instead of 470 MHz.