### PR TITLE
mxl58x improve rfsource to select any combination of modulator/inputs

### DIFF
--- a/drivers/media/dvb-frontends/mxl58x.c
+++ b/drivers/media/dvb-frontends/mxl58x.c
@@ -1544,8 +1544,17 @@ struct dvb_frontend *mxl58x_attach(struct i2c_adapter *i2c,
 		if((demod ==6)||(demod ==7))
 			state->rf_in = 0;
 
-		if (rfsource > 0 && rfsource < 5)
-			state->rf_in = 4 - rfsource;
+		if (rfsource > 0)
+		{
+			if(demod==0) state->rf_in = (unsigned int)(rfsource & 0x3);
+			if(demod==1) state->rf_in = (unsigned int)(rfsource >> 2) & 0x3;
+			if(demod==2) state->rf_in = (unsigned int)(rfsource >> 4) & 0x3;
+			if(demod==3) state->rf_in = (unsigned int)(rfsource >> 6) & 0x3;
+			if(demod==4) state->rf_in = (unsigned int)(rfsource >> 8) & 0x3;
+			if(demod==5) state->rf_in = (unsigned int)(rfsource >> 10) & 0x3;
+			if(demod==6) state->rf_in = (unsigned int)(rfsource >> 12) & 0x3;
+			if(demod==7) state->rf_in = (unsigned int)(rfsource >> 14) & 0x3;
+		}
 		
 		if (mode==2)
 			state->rf_in = 0;


### PR DESCRIPTION
With this patch we can use rfsource mxl58x module parameter to configure any arbitrary configuration of demods/inputs. We might want 7 demods to input 3 and 1 to input 2, or 5 to input 0, 2 to input 1 and 1 to input 2. All these setups can now be configured.

We use two bits to select input for each demod. demod 0 uses the two less significant bits and demod 7 the two most significant bits of a 16bit value.
Value of 1455 (binary 0000010110101111) is the same as default without using rfsource.
Example usage:
a. 0-6 demods to input 3, 7th demod to input 2
1011111111111111 => 49151
b. 0-4 demods to input 0, 5-6 demods to input 1, 7th demod to input 2
1001010000000000 => 37888
This has been tested in production and works well.

Only issue is that you can not reconfigure on the fly, you need to unload and reload modules with new value.