### PR TITLE
tbsecp3: get rid of pci_alloc_consistent usage

### DIFF
--- a/drivers/media/pci/tbsecp3/tbsecp3-dma.c
+++ b/drivers/media/pci/tbsecp3/tbsecp3-dma.c
@@ -149,9 +149,9 @@ int tbsecp3_dma_init(struct tbsecp3_dev *dev)
 		adapter->dma.buffer_size = dma_pkts[i] * TS_PACKET_SIZE;
 		adapter->dma.page_size = adapter->dma.buffer_size * TBSECP3_DMA_BUFFERS;
 
-		adapter->dma.buf[0] = pci_alloc_consistent(dev->pci_dev,
-				adapter->dma.page_size + 0x100,
-				&adapter->dma.dma_addr);
+		adapter->dma.buf[0] = dma_alloc_coherent(&dev->pci_dev->dev,
+							 adapter->dma.page_size + 0x100,
+							 &adapter->dma.dma_addr, GFP_KERNEL);
 		if (!adapter->dma.buf[0])
 			goto err;
 


### PR DESCRIPTION
pci_alloc_consistent is a legacy function that allocates GFP_ATOMIC memory, the
driver seemingly doesn't need this and it breaks probing on some hosts (notably
the PINE64 Quartz64 Model A).

Replace this with dma_alloc_coherent using GFP_KERNEL memory, which is what is
preferred for generally all kernel allocations.

I don't have the TV tuner card to test this with, but someone who does tested
this patch for me and confirmed it to have fixed their issue.

Also please for the love of everything that is holy, upstream your drivers so these things can be corrected tree-wide.