### PR TITLE
mtv23x: some improvements

### DIFF
--- a/drivers/media/dvb-frontends/mtv23x.c
+++ b/drivers/media/dvb-frontends/mtv23x.c
@@ -931,6 +931,7 @@ static int rtvRF_SetOfdmPara(struct mtv23x_dev*dev,enum E_RTV_SERVICE_TYPE eServ
 	int nRet = 0;
 	int nNumAdcType = 0;
 	const struct RTV_ADC_CFG_INFO *ptOfdmCfgTbl = NULL;
+	int freqMHz = dwChFreqKHz / 1000;
 	
 	struct RTV_ADC_CFG_INFO g_atAdcCfgTbl_ISDBT_6MHz[] = {
 	/*8*/	 {0x00, 0x06, 0x48, 0x2E, 0x29,0x10410410,0x1B6C8B43,0x208208,0x41},
@@ -959,10 +960,10 @@ static int rtvRF_SetOfdmPara(struct mtv23x_dev*dev,enum E_RTV_SERVICE_TYPE eServ
 		switch (eLpfBwType) {
 		case RTV_BW_MODE_6MHZ:
 		case RTV_BW_MODE_430KHZ:
-			if ((dwChFreqKHz == 485143) || (dwChFreqKHz == 503143)
-			|| (dwChFreqKHz == 539143) || (dwChFreqKHz == 647143)
-			|| (dwChFreqKHz == 665143) || (dwChFreqKHz == 683143)
-			|| (dwChFreqKHz == 755143))
+			if ((freqMHz == 485) || (freqMHz == 503)
+			|| (freqMHz == 539) || (freqMHz == 647)
+			|| (freqMHz == 665) || (freqMHz == 683)
+			|| (freqMHz == 755))
 				nNumAdcType = 0; /* ADC 8MHz */
 
 			ptOfdmCfgTbl = &g_atAdcCfgTbl_ISDBT_6MHz[nNumAdcType];
@@ -1019,13 +1020,13 @@ static int rtvRF_SetOfdmPara(struct mtv23x_dev*dev,enum E_RTV_SERVICE_TYPE eServ
 		break;
 
 	case RTV_SERVICE_UHF_ISDBT_13seg:
-		if ((dwChFreqKHz == 551143) || (dwChFreqKHz == 581143) ||
-		(dwChFreqKHz == 611143) || (dwChFreqKHz == 617143) ||
-		(dwChFreqKHz == 647143) || (dwChFreqKHz == 677143) ||
-		(dwChFreqKHz == 707143) || (dwChFreqKHz == 737143) ||
-		(dwChFreqKHz == 767143) || (dwChFreqKHz == 797143))
+		if ((freqMHz == 551) || (freqMHz == 581) ||
+		(freqMHz == 611) || (freqMHz == 617) ||
+		(freqMHz == 647) || (freqMHz == 677) ||
+		(freqMHz == 707) || (freqMHz == 737) ||
+		(freqMHz == 767) || (freqMHz == 797))
 			nNumAdcType = 2; /* ADC 19.2MHz */
-		else if ((dwChFreqKHz == 491143) || (dwChFreqKHz == 521143))
+		else if ((freqMHz == 491) || (freqMHz == 521))
 			nNumAdcType = 3; /* ADC 20.0MHz */
 		else
 			nNumAdcType = 4; /* ADC 20.48MHz */


### PR DESCRIPTION
Improving service type selection:
the service type is not expected to be ORed with different values. now, it properly checks if the frequency is VHF or UFH and if the user wants sb mode or not

Instead of comparing a frequency that equals exactly some KHz values, now it uses MHz.
I'm not sure what is this needed for, but I think it makes more sense to ignore the KHz and compare it against MHz