### PR TITLE
tbsecp3: fix compiler warnings

### DIFF
--- a/drivers/media/pci/tbsecp3/tbsecp3-dvb.c
+++ b/drivers/media/pci/tbsecp3/tbsecp3-dvb.c
@@ -173,7 +173,7 @@ static int tbs6302se_read_mac(struct tbsecp3_adapter *adap)
 		//printk(" the receiver always busy !\n");
 		//check mcu status
 		*(u32 *)tmpbuf = tbs_read( BASE_ADDRESS_24CXX,  STATUS_MAC16_24CXX );
-		if((tmpbuf[0]&0x4) == 1) // bit2==1 mcu busy
+		if((tmpbuf[0]&0x4) != 0) // bit2==1 mcu busy
 		{
 			//printk("MCU status is busy!!!\n" );
 			// release cs;
@@ -241,7 +241,7 @@ static int tbs6304_read_mac(struct tbsecp3_adapter *adap)
 		//printk(" the receiver always busy !\n");
 		//check mcu status
 		*(u32 *)tmpbuf = tbs_read( BASE_ADDRESS_24CXX,  STATUS_MAC16_24CXX );
-		if((tmpbuf[0]&0x4) == 1) // bit2==1 mcu busy
+		if((tmpbuf[0]&0x4) != 0) // bit2==1 mcu busy
 		{
 			//printk("MCU status is busy!!!\n" );
 			// release cs;
@@ -347,7 +347,7 @@ static int tbs6308_read_mac_ext(struct tbsecp3_adapter *adap)
 		ret = 0;
 		//check mcu status
 		*(u32 *)tmpbuf = tbs_read_ext(adap, BASE_ADDRESS_24CXX,  STATUS_MAC16_24CXX );
-		if((tmpbuf[0]&0x4) == 1) // bit2==1 mcu busy
+		if((tmpbuf[0]&0x4) != 0) // bit2==1 mcu busy
 		{
 			//printk("MCU status is busy!!!\n" );
 			// release cs;
@@ -410,7 +410,7 @@ static void tbs6301_read_mac(struct tbsecp3_adapter *adap)
 		printk(" the receiver always busy !\n");
 		//check mcu status
 		*(u32 *)tmpbuf = tbs_read( BASE_ADDRESS_24CXX,  STATUS_MAC16_24CXX );
-		if((tmpbuf[0]&0x4) == 1) // bit2==1 mcu busy
+		if((tmpbuf[0]&0x4) != 0) // bit2==1 mcu busy
 		{
 			printk("MCU status is busy!!!\n" );
 			// release cs;

--- a/drivers/media/pci/tbsecp3/tbsecp3-dvb.c
+++ b/drivers/media/pci/tbsecp3/tbsecp3-dvb.c
@@ -1581,16 +1581,14 @@ static int tbsecp3_frontend_attach(struct tbsecp3_adapter *adapter)
 		adapter->fe = dvb_attach(tas2971_attach, &tbs6308_demod_cfg, i2c);
 		if (adapter->fe == NULL)
 		    goto frontend_atach_fail;
-		    if(adapter->nr <4)
-		    {
-			    if(tbs6304_read_mac(adapter)==0)
-				    tbs6304_read_mac(adapter);
-		    }
-		    else
-		    {
-			    if(tbs6308_read_mac_ext(adapter)==0)
-				    tbs6308_read_mac_ext(adapter);//try again
-		    }
+
+		if(adapter->nr < 4) {
+		    if(tbs6304_read_mac(adapter)==0)
+			tbs6304_read_mac(adapter);
+		} else {
+		    if(tbs6308_read_mac_ext(adapter)==0)
+			tbs6308_read_mac_ext(adapter);//try again
+		}
 		break;
 
 	case TBSECP3_BOARD_TBS6304:


### PR DESCRIPTION
The bitwise comparisons checking for mcu busy on bit 2 always evaluated false.

The tbsecp3 directory now only warns for one unused variable and two unused functions in tbsecp3-dbc.c which left for now.