### PR TITLE
dvb_frontend.c: continue trying to tune on frontend timeout

### DIFF
--- a/drivers/media/dvb-core/dvb_frontend.c
+++ b/drivers/media/dvb-core/dvb_frontend.c
@@ -471,6 +471,10 @@ static int dvb_frontend_swzigzag_autotune(struct dvb_frontend *fe, int check_wra
 	if (fe->ops.set_frontend)
 		fe_set_err = fe->ops.set_frontend(fe);
 	*c = tmp;
+	if (fe_set_err == -ETIMEDOUT) {
+		fepriv->state = FESTATE_RETUNE;
+		return 0;
+	}
 	if (fe_set_err < 0) {
 		fepriv->state = FESTATE_ERROR;
 		return fe_set_err;
@@ -508,6 +512,10 @@ static void dvb_frontend_swzigzag(struct dvb_frontend *fe)
 			if (fe->ops.set_frontend)
 				retval = fe->ops.set_frontend(fe);
 			*c = tmp;
+			if (retval == -ETIMEDOUT) {
+				fepriv->state = FESTATE_RETUNE;
+				return;
+			}
 			if (retval < 0)
 				fepriv->state = FESTATE_ERROR;
 			else


### PR DESCRIPTION
Some buggy frontends cannot respond to tune commands in time, but will tune successfully in next cycle.
FESTATE_ERROR breaks any further attempt to tune, so set FESTATE_RETUNE instead.