### PR TITLE
Update isl6422.c: Allow loading by setting attach function as GPL

### DIFF
--- a/drivers/media/dvb-frontends/isl6422.c
+++ b/drivers/media/dvb-frontends/isl6422.c
@@ -310,7 +310,7 @@ exit:
 	fe->sec_priv = NULL;
 	return NULL;
 }
-EXPORT_SYMBOL(isl6422_attach);
+EXPORT_SYMBOL_GPL(isl6422_attach);
 
 MODULE_DESCRIPTION("ISL6422 SEC");
 MODULE_AUTHOR("Luis Alves");


### PR DESCRIPTION
The ISL6422 LNB power chip refuses to work in modern kernels due to a restriction.
By using EXPORT_SYMBOL_GPL, the kernel module loads correctly once again.

Also see: https://lore.kernel.org/lkml/20230731083806.453036-6-hch@lst.de/