### PR TITLE
m88rs6060: skip cold initialization when firmware is already running

### DIFF
--- a/drivers/media/dvb-frontends/m88rs6060.c
+++ b/drivers/media/dvb-frontends/m88rs6060.c
@@ -3366,7 +3366,22 @@ static int m88rs6060_ready(struct m88rs6060_dev *dev)
 		
 	dev_dbg(&dev->base->i2c->dev, "%s", __func__);
 
-	//rest the harware and wake up the demod and tuner;
+	/*
+	 * Only run the cold-boot sequence when the chip is actually cold; if it's
+	 * already warm, leave it alone.
+	 */
+	ret = regmap_read(dev->regmap, 0xb9, &val);
+	if (!ret && val) {
+		dev_info(&i2c->dev, "found a '%s' already in warm state\n",
+			 dev->fe.ops.info.name);
+		dev_info(&i2c->dev, "firmware version:%X\n", val);
+		m88res6060_set_ts_mode(dev);
+		regmap_read(dev->regmap, 0x4d, &val);
+		regmap_write(dev->regmap, 0x4d, val & 0xfd);
+		return 0;
+	}
+
+	//reset the hardware and wake up the demod and tuner;
 	m88rs6060_hard_rest(dev);
 	rs6060_init(dev);
 


### PR DESCRIPTION
This fixes https://github.com/tbsdtv/linux_media/issues/410.

On a plain host reboot (no USB power cycle), m88rs6060_probe() unconditionally calls m88rs6060_ready(), which unconditionally:

- Hard-resets the demod (m88rs6060_hard_rest())
- Re-initializes tuner/gain registers (rs6060_init())
- Issues a global/DiSEqC/FEC reset (0x07 = 0xe0 → 0x00)
- Re-downloads and re-flashes firmware

Since the USB device is typically never actually power-cycled across a plain reboot, this runs against a demod chip that is still fully warm — firmware loaded. The result is intermittent misbehavior after the box comes back up: transponders lock, but with picture breakup / continuity-counter errors on some channels. A genuine power cycle is unaffected, since in that case the chip really is cold and needs this sequence.

If the chip is already warm (0xb9 non-zero), skip the hard reset, tuner/gain re-init, DiSEqC/FEC reset, and firmware reflash entirely — just reapply TS mode and return. If it's genuinely cold (0xb9 reads 0), fall through to the existing, unmodified cold-boot sequence.